### PR TITLE
Bug: localStorage에 데이터가 있어도 MockUp Data보여주는 문제 해결(#33)

### DIFF
--- a/src/Components/TodoList/Utils/TodoService.tsx
+++ b/src/Components/TodoList/Utils/TodoService.tsx
@@ -24,7 +24,7 @@ interface TodoServiceReturn {
 }
 
 export const TodoService = (): TodoServiceReturn => {
-  const [todoState, setTodoState] = useState<ITodoState[]>(initialTodos);
+  const [todoState, setTodoState] = useState<ITodoState[]>([]);
 
   useEffect(() => {
     loadData();
@@ -40,7 +40,7 @@ export const TodoService = (): TodoServiceReturn => {
 
   const loadData = useCallback(() => {
     const data = LOCAL_STORAGE.get("todos");
-    const temp = data ? data : MockUp;
+    const temp = data ? data : initialTodos;
     setTodoState(temp);
   }, []);
 


### PR DESCRIPTION
서버로 접속할 때, localStorage에 데이터가 있음에도 처음에 MockUp Data가 살짝 보이는 문제 수정.
기본 todoState에 initialTodos대신 빈 배열 입력, localStorage에 아무것도 없을 시 initialTodos 입력.

closed #33 